### PR TITLE
Add support for passing jvm-opts to dynamo

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ Note: This should not be used in conjunction with the `:in-memory?` parameter. I
 :dynamodb-local {:db-path "/path/to/desired/db/output/"}
 ```
 
+#### :jvm-opts
+
+Pass JVM options to the DynamoDB process. Behaves the same as the 'normal' :jvm-opts in a project.clj
+
+```clojure
+:dynamodb-local {:jvm-opts ["-server" "-Xmx512m"]}
+```
+
 ## License
 
 Copyright © 2014 Donovan McGillen


### PR DESCRIPTION
Adds :jvm-opts as an option in the :dynamodb-local map
