### PR TITLE
Move download directory to user.home

### DIFF
--- a/src/leiningen/dynamodb_local.clj
+++ b/src/leiningen/dynamodb_local.clj
@@ -2,13 +2,14 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
             [leiningen.core.main :as main])
-  (:import [java.nio.file Files Paths LinkOption Path]
+  (:import [java.io File]
+           [java.nio.file Files Paths LinkOption Path]
            [java.nio.file.attribute FileAttribute]
            [net.lingala.zip4j.core ZipFile]))
 
 (def download-url "http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_latest.zip")
 
-(def dynamo-directory ".lein-dynamodb-local")
+(def dynamo-directory (str (System/getProperty "user.home") File/separator ".lein-dynamodb-local"))
 
 (defn ->path [str & strs]
   {:pre [(string? str) (every? string? strs)]}


### PR DESCRIPTION
This change moves the download directory to `~/.lein-dynamodb-local` to avoid downloading the DynamoDB Local release (which is quite large) for every project/build. If you have Jenkins jobs that wipe out the workspace, this avoids a lot of downloads.

There's a small chance of conflict if multiple builds are run simultaneously, for the first time, for a single user. There's a lot of benefit here though, and using the home dir [is a common approach](https://github.com/flapdoodle-oss/de.flapdoodle.embed.process).
