### PR TITLE
Allow port to be specified via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Set the port that you want DynamoDB Local to run on (defaults to 8000).
 :dynamodb-local {:port 12345}
 ```
 
+It is also possible to set the port by using the environment variable `DYNAMODB_PORT`.
+
 #### :in-memory?
 
 Set if you want DynamoDB Local to be run in memory (defaults to false).

--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :eval-in-leiningen true
-  :dependencies [[net.lingala.zip4j/zip4j "1.3.2"]]
+  :dependencies [[environ "1.0.0"]
+                 [net.lingala.zip4j/zip4j "1.3.2"]]
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :creds :gpg}]])

--- a/src/leiningen/dynamodb_local.clj
+++ b/src/leiningen/dynamodb_local.clj
@@ -1,6 +1,7 @@
 (ns leiningen.dynamodb-local
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
+            [environ.core :refer [env]]
             [leiningen.core.main :as main])
   (:import [java.io File]
            [java.nio.file Files Paths LinkOption Path]
@@ -41,7 +42,7 @@
 (defn dynamo-options
   "Use DynamoDB Local options provided or default values"
   [project]
-  (merge {:port 8000
+  (merge {:port (Integer/valueOf (env :dynamodb-port "8000"))
           :in-memory? false
           :db-path dynamo-directory}
          (:dynamodb-local project)))


### PR DESCRIPTION
Add a dependency on `environ` which we use to pull the `DYNAMODB_PORT` value from system environment variables. That value will be overridden by anything specified in the `project.clj`.

This should help with use-cases like Jenkins where people tend to randomly assign a port to particular things at runtime.
